### PR TITLE
Update check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,10 @@ jobs:
         shell: cmd
         run: bazelisk build //:EXRay
 
+      - name: Run unit tests
+        shell: cmd
+        run: bazelisk test //:update_checker_test --test_output=errors
+
       - name: Cache test images
         uses: actions/cache@v4
         with:

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 cc_library(
     name = "image_lib",
@@ -48,6 +48,7 @@ cc_binary(
         "src/viewport.cpp",
         "src/timing.h",
         "src/crash_handler.h",
+        "src/update_checker.h",
         "src/resource.h",
     ],
     additional_linker_inputs = [":app_resources"],
@@ -70,6 +71,19 @@ cc_binary(
         "-DEFAULTLIB:comctl32.lib",
         "-DEFAULTLIB:ole32.lib",
         "-DEFAULTLIB:dbghelp.lib",
+        "-DEFAULTLIB:winhttp.lib",
         "$(location :app_resources)",
+    ],
+)
+
+cc_test(
+    name = "update_checker_test",
+    srcs = [
+        "tests/update_checker_test.cpp",
+        "src/update_checker.h",
+    ],
+    includes = ["src"],
+    linkopts = [
+        "-DEFAULTLIB:winhttp.lib",
     ],
 )

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,7 +40,7 @@ The workflow only runs for tags pushed from `main`.
 - [x] Window title shows current filename
 - [x] Embed `VERSIONINFO` resource in RC file (version, copyright, description)
 - [ ] Investigate scroll stutter fix (DirectComposition swap chain or other approach from BUGS.md)
-- [ ] Update check — background WinHTTP GET to `api.github.com/repos/hughes/EXRay/releases/latest`, compare `tag_name` semver to current version. If newer: asterisk on Help menu, "Update available" line in About dialog. No interruptions. Requires at least one published release to test against.
+- [x] Update check — background WinHTTP GET to `api.github.com/repos/hughes/EXRay/releases/latest`, compare `tag_name` semver to current version. If newer: asterisk on Help menu, "Update available" line in About dialog. No interruptions. Requires at least one published release to test against.
 - [x] Make sure all environment-specific stuff referencing the local development paths is removed.
 
 ## 2. Testing

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -332,7 +332,25 @@ bool App::Initialize(HINSTANCE hInstance, int nCmdShow, LPWSTR cmdLine, StartupT
         }
     }
 
+    if (!m_smokeTest)
+        StartUpdateCheck();
+
     return true;
+}
+
+void App::StartUpdateCheck()
+{
+    m_updateCheckComplete = false;
+    HWND hwnd = m_window.GetHwnd();
+
+    m_updateThread = std::thread(
+        [this, hwnd]()
+        {
+            m_updateResult =
+                UpdateChecker::Check(EXRAY_VERSION_MAJOR, EXRAY_VERSION_MINOR, EXRAY_VERSION_PATCH);
+            m_updateCheckComplete = true;
+            PostMessageW(hwnd, WM_APP + 1, 0, 0);
+        });
 }
 
 int App::Run()
@@ -358,6 +376,8 @@ int App::Run()
             {
                 if (m_preloadThread.joinable())
                     m_preloadThread.join();
+                if (m_updateThread.joinable())
+                    m_updateThread.join();
                 return static_cast<int>(msg.wParam);
             }
             if (!TranslateAcceleratorW(m_window.GetHwnd(), m_window.GetAccelTable(), &msg))
@@ -377,6 +397,20 @@ int App::Run()
         {
             FinishPreload();
             StartPreload();
+        }
+
+        // Handle update check completion
+        if (m_updateCheckComplete && !m_updateAvailable)
+        {
+            if (m_updateThread.joinable())
+                m_updateThread.join();
+            if (m_updateResult.updateAvailable)
+            {
+                m_updateAvailable = true;
+                m_updateVersion = m_updateResult.newVersion;
+                m_window.MarkHelpMenuUpdate(true);
+            }
+            m_updateCheckComplete = false;
         }
 
         if (m_needsRedraw)
@@ -550,6 +584,21 @@ void App::OnCommand(int commandId)
         HICON bigIcon = static_cast<HICON>(
             LoadImageW(m_hInstance, MAKEINTRESOURCEW(IDI_APPICON), IMAGE_ICON, 64, 64, LR_DEFAULTCOLOR));
 
+        std::wstring content = L"Version " EXRAY_VERSION_WSTR L"\n"
+                               EXRAY_COPYRIGHT_W L"\n\n"
+                               L"<a href=\"https://github.com/hughes/EXRay\">github.com/hughes/EXRay</a>\n"
+                               L"Open-source. Free of ads, forever.";
+
+        if (m_updateAvailable)
+        {
+            wchar_t verW[32];
+            MultiByteToWideChar(CP_UTF8, 0, m_updateVersion.c_str(), -1, verW, 32);
+            content += L"\n\n<a href=\"https://github.com/hughes/EXRay/releases/latest\">"
+                       L"Update available: v";
+            content += verW;
+            content += L"</a>";
+        }
+
         TASKDIALOGCONFIG tdc = {sizeof(tdc)};
         tdc.hwndParent = m_window.GetHwnd();
         tdc.hInstance = m_hInstance;
@@ -558,10 +607,7 @@ void App::OnCommand(int commandId)
         tdc.hMainIcon = bigIcon;
         tdc.pszWindowTitle = L"About EXRay";
         tdc.pszMainInstruction = L"EXRay";
-        tdc.pszContent = L"Version " EXRAY_VERSION_WSTR L"\n"
-                         EXRAY_COPYRIGHT_W L"\n\n"
-                         L"<a href=\"https://github.com/hughes/EXRay\">github.com/hughes/EXRay</a>\n"
-                         L"Open-source. Free of ads, forever.";
+        tdc.pszContent = content.c_str();
         tdc.pfCallback = [](HWND hwnd, UINT msg, WPARAM, LPARAM lParam, LONG_PTR) -> HRESULT
         {
             if (msg == TDN_HYPERLINK_CLICKED)

--- a/src/app.h
+++ b/src/app.h
@@ -10,6 +10,7 @@
 #include "image.h"
 #include "renderer.h"
 #include "timing.h"
+#include "update_checker.h"
 #include "viewport.h"
 #include "window.h"
 
@@ -37,6 +38,7 @@ class App
     void SaveTabState();
     void StartPreload();
     void FinishPreload();
+    void StartUpdateCheck();
     void EvictDistantTabs();
     void Render();
     void UpdateImageStatusText();
@@ -100,6 +102,13 @@ class App
     ImageData m_preloadImage;
     HistogramData m_preloadHistogram;
     std::atomic<bool> m_preloadComplete{false};
+
+    // Update check state
+    std::thread m_updateThread;
+    UpdateCheckResult m_updateResult;
+    std::atomic<bool> m_updateCheckComplete{false};
+    bool m_updateAvailable = false;
+    std::string m_updateVersion;
 
     // Smoke test mode — force WARP, suppress dialogs, exit after first frame
     bool m_smokeTest = false;

--- a/src/update_checker.h
+++ b/src/update_checker.h
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#ifndef UNICODE
+#define UNICODE
+#endif
+
+#include <windows.h>
+#include <winhttp.h>
+
+#include <cstdio>
+#include <cstring>
+
+struct UpdateCheckResult
+{
+    bool updateAvailable = false;
+    char newVersion[32] = {};
+};
+
+namespace UpdateChecker
+{
+
+inline int PackVersion(int major, int minor, int patch)
+{
+    return (major << 20) | (minor << 10) | patch;
+}
+
+// Parse "tag_name":"vX.Y.Z" from GitHub API JSON response.
+inline int ParseTagVersion(const char* json, char* versionOut, size_t versionOutSize)
+{
+    const char* key = strstr(json, "\"tag_name\"");
+    if (!key)
+        return 0;
+
+    const char* colon = strchr(key + 10, ':');
+    if (!colon)
+        return 0;
+
+    const char* q1 = strchr(colon, '"');
+    if (!q1)
+        return 0;
+    q1++;
+
+    const char* q2 = strchr(q1, '"');
+    if (!q2 || q2 - q1 > 30)
+        return 0;
+
+    char buf[32];
+    size_t len = static_cast<size_t>(q2 - q1);
+    memcpy(buf, q1, len);
+    buf[len] = '\0';
+
+    const char* ver = buf;
+    if (ver[0] == 'v' || ver[0] == 'V')
+        ver++;
+
+    int major = 0, minor = 0, patch = 0;
+    if (sscanf(ver, "%d.%d.%d", &major, &minor, &patch) < 2)
+        return 0;
+
+    if (versionOut && versionOutSize > 0)
+    {
+        size_t verLen = strlen(ver);
+        if (verLen < versionOutSize)
+        {
+            memcpy(versionOut, ver, verLen);
+            versionOut[verLen] = '\0';
+        }
+    }
+
+    return PackVersion(major, minor, patch);
+}
+
+// Synchronous HTTPS GET to GitHub releases API. Call from a background thread.
+inline UpdateCheckResult Check(int currentMajor, int currentMinor, int currentPatch)
+{
+    UpdateCheckResult result = {};
+    int currentPacked = PackVersion(currentMajor, currentMinor, currentPatch);
+
+    HINTERNET hSession = WinHttpOpen(L"EXRay-UpdateCheck/1.0", WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY,
+                                     WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+    if (!hSession)
+        return result;
+
+    WinHttpSetTimeouts(hSession, 10000, 10000, 10000, 15000);
+
+    HINTERNET hConnect =
+        WinHttpConnect(hSession, L"api.github.com", INTERNET_DEFAULT_HTTPS_PORT, 0);
+    if (!hConnect)
+    {
+        WinHttpCloseHandle(hSession);
+        return result;
+    }
+
+    HINTERNET hRequest =
+        WinHttpOpenRequest(hConnect, L"GET", L"/repos/hughes/EXRay/releases/latest", nullptr,
+                           WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, WINHTTP_FLAG_SECURE);
+    if (!hRequest)
+    {
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        return result;
+    }
+
+    if (!WinHttpSendRequest(hRequest, WINHTTP_NO_ADDITIONAL_HEADERS, 0, WINHTTP_NO_REQUEST_DATA, 0,
+                            0, 0) ||
+        !WinHttpReceiveResponse(hRequest, nullptr))
+    {
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        return result;
+    }
+
+    // Check HTTP status
+    DWORD statusCode = 0;
+    DWORD size = sizeof(statusCode);
+    WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                        WINHTTP_HEADER_NAME_BY_INDEX, &statusCode, &size,
+                        WINHTTP_NO_HEADER_INDEX);
+    if (statusCode != 200)
+    {
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+        return result;
+    }
+
+    // Read response body (cap at 32KB — actual response is ~2-3KB)
+    char body[32768];
+    DWORD totalRead = 0;
+    DWORD bytesRead = 0;
+
+    while (totalRead < sizeof(body) - 1)
+    {
+        if (!WinHttpReadData(hRequest, body + totalRead, sizeof(body) - 1 - totalRead, &bytesRead))
+            break;
+        if (bytesRead == 0)
+            break;
+        totalRead += bytesRead;
+    }
+    body[totalRead] = '\0';
+
+    char remoteVersion[32] = {};
+    int remotePacked = ParseTagVersion(body, remoteVersion, sizeof(remoteVersion));
+    if (remotePacked > currentPacked)
+    {
+        result.updateAvailable = true;
+        memcpy(result.newVersion, remoteVersion, sizeof(result.newVersion));
+    }
+
+    WinHttpCloseHandle(hRequest);
+    WinHttpCloseHandle(hConnect);
+    WinHttpCloseHandle(hSession);
+    return result;
+}
+
+} // namespace UpdateChecker

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -350,6 +350,21 @@ void Window::UpdateHDRMenu(bool hdrCapable, bool hdrEnabled)
     EnableMenuItem(menu, IDM_VIEW_GAMMA_DOWN, MF_BYCOMMAND | gammaEnable);
 }
 
+void Window::MarkHelpMenuUpdate(bool available)
+{
+    HMENU menu = GetMenu(m_hwnd);
+    if (!menu)
+        menu = m_savedMenu;
+    if (!menu)
+        return;
+
+    // Help menu is at position 2 (File=0, View=1, Help=2)
+    ModifyMenuW(menu, 2, MF_BYPOSITION | MF_POPUP,
+                reinterpret_cast<UINT_PTR>(GetSubMenu(menu, 2)),
+                available ? L"&Help *" : L"&Help");
+    DrawMenuBar(m_hwnd);
+}
+
 void Window::AddTab(int index, const wchar_t* label)
 {
     if (!m_tabBar)

--- a/src/window.h
+++ b/src/window.h
@@ -57,6 +57,7 @@ class Window
     // Update View menu check marks / radio state
     void UpdateMenuChecks(bool showHistogram, int histogramChannel, bool showGrid);
     void UpdateHDRMenu(bool hdrCapable, bool hdrEnabled);
+    void MarkHelpMenuUpdate(bool available);
 
     // Tab bar management
     void AddTab(int index, const wchar_t* label);

--- a/tests/update_checker_test.cpp
+++ b/tests/update_checker_test.cpp
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Unit tests for UpdateChecker semver parsing (no network calls).
+// Build & run: bazelisk test //:update_checker_test
+
+#include "update_checker.h"
+
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define TEST(name)                                                                                 \
+    static void test_##name();                                                                     \
+    struct Register_##name                                                                         \
+    {                                                                                              \
+        Register_##name() { test_##name(); }                                                       \
+    } reg_##name;                                                                                  \
+    static void test_##name()
+
+#define EXPECT(expr)                                                                               \
+    do                                                                                             \
+    {                                                                                              \
+        tests_run++;                                                                               \
+        if (expr)                                                                                  \
+        {                                                                                          \
+            tests_passed++;                                                                        \
+        }                                                                                          \
+        else                                                                                       \
+        {                                                                                          \
+            fprintf(stderr, "  FAIL: %s:%d: %s\n", __FILE__, __LINE__, #expr);                     \
+        }                                                                                          \
+    } while (0)
+
+// --- PackVersion ---
+
+TEST(PackVersion_basic)
+{
+    EXPECT(UpdateChecker::PackVersion(0, 1, 0) > 0);
+    EXPECT(UpdateChecker::PackVersion(1, 0, 0) > UpdateChecker::PackVersion(0, 99, 99));
+}
+
+TEST(PackVersion_ordering)
+{
+    EXPECT(UpdateChecker::PackVersion(0, 2, 0) > UpdateChecker::PackVersion(0, 1, 0));
+    EXPECT(UpdateChecker::PackVersion(0, 1, 1) > UpdateChecker::PackVersion(0, 1, 0));
+    EXPECT(UpdateChecker::PackVersion(1, 0, 0) > UpdateChecker::PackVersion(0, 9, 9));
+    EXPECT(UpdateChecker::PackVersion(0, 1, 0) == UpdateChecker::PackVersion(0, 1, 0));
+}
+
+// --- ParseTagVersion ---
+
+TEST(ParseTagVersion_standard)
+{
+    const char* json = R"({"tag_name": "v1.2.3", "name": "Release 1.2.3"})";
+    char ver[32] = {};
+    int packed = UpdateChecker::ParseTagVersion(json, ver, sizeof(ver));
+    EXPECT(packed == UpdateChecker::PackVersion(1, 2, 3));
+    EXPECT(strcmp(ver, "1.2.3") == 0);
+}
+
+TEST(ParseTagVersion_no_v_prefix)
+{
+    const char* json = R"({"tag_name": "2.0.1"})";
+    char ver[32] = {};
+    int packed = UpdateChecker::ParseTagVersion(json, ver, sizeof(ver));
+    EXPECT(packed == UpdateChecker::PackVersion(2, 0, 1));
+    EXPECT(strcmp(ver, "2.0.1") == 0);
+}
+
+TEST(ParseTagVersion_major_minor_only)
+{
+    // sscanf with %d.%d.%d should parse two integers, patch defaults to 0
+    const char* json = R"({"tag_name": "v3.5"})";
+    char ver[32] = {};
+    int packed = UpdateChecker::ParseTagVersion(json, ver, sizeof(ver));
+    EXPECT(packed == UpdateChecker::PackVersion(3, 5, 0));
+}
+
+TEST(ParseTagVersion_zero_version)
+{
+    const char* json = R"({"tag_name": "v0.0.0"})";
+    char ver[32] = {};
+    int packed = UpdateChecker::ParseTagVersion(json, ver, sizeof(ver));
+    EXPECT(packed == 0);
+}
+
+TEST(ParseTagVersion_realistic_github_response)
+{
+    // Subset of a real GitHub API response
+    const char* json =
+        R"({"url":"https://api.github.com/repos/hughes/EXRay/releases/1234",)"
+        R"("tag_name":"v0.2.0","target_commitish":"main","name":"v0.2.0",)"
+        R"("draft":false,"prerelease":false,"body":"Release notes here"})";
+    char ver[32] = {};
+    int packed = UpdateChecker::ParseTagVersion(json, ver, sizeof(ver));
+    EXPECT(packed == UpdateChecker::PackVersion(0, 2, 0));
+    EXPECT(strcmp(ver, "0.2.0") == 0);
+}
+
+TEST(ParseTagVersion_missing_tag_name)
+{
+    const char* json = R"({"name": "v1.0.0"})";
+    char ver[32] = {};
+    int packed = UpdateChecker::ParseTagVersion(json, ver, sizeof(ver));
+    EXPECT(packed == 0);
+    EXPECT(ver[0] == '\0');
+}
+
+TEST(ParseTagVersion_empty_string)
+{
+    char ver[32] = {};
+    int packed = UpdateChecker::ParseTagVersion("", ver, sizeof(ver));
+    EXPECT(packed == 0);
+}
+
+TEST(ParseTagVersion_garbage)
+{
+    const char* json = R"({"tag_name": "not-a-version"})";
+    char ver[32] = {};
+    int packed = UpdateChecker::ParseTagVersion(json, ver, sizeof(ver));
+    EXPECT(packed == 0);
+}
+
+TEST(ParseTagVersion_null_version_out)
+{
+    const char* json = R"({"tag_name": "v1.0.0"})";
+    int packed = UpdateChecker::ParseTagVersion(json, nullptr, 0);
+    EXPECT(packed == UpdateChecker::PackVersion(1, 0, 0));
+}
+
+// --- Simulated update check logic (no network) ---
+
+TEST(UpdateLogic_newer_version_detected)
+{
+    int current = UpdateChecker::PackVersion(0, 1, 0);
+    const char* json = R"({"tag_name": "v0.2.0"})";
+    char ver[32] = {};
+    int remote = UpdateChecker::ParseTagVersion(json, ver, sizeof(ver));
+    EXPECT(remote > current);
+}
+
+TEST(UpdateLogic_same_version)
+{
+    int current = UpdateChecker::PackVersion(0, 1, 0);
+    const char* json = R"({"tag_name": "v0.1.0"})";
+    char ver[32] = {};
+    int remote = UpdateChecker::ParseTagVersion(json, ver, sizeof(ver));
+    EXPECT(!(remote > current));
+}
+
+TEST(UpdateLogic_older_version)
+{
+    int current = UpdateChecker::PackVersion(1, 0, 0);
+    const char* json = R"({"tag_name": "v0.9.9"})";
+    char ver[32] = {};
+    int remote = UpdateChecker::ParseTagVersion(json, ver, sizeof(ver));
+    EXPECT(!(remote > current));
+}
+
+int main()
+{
+    // Tests already ran via static initialization
+    printf("update_checker_test: %d/%d passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}


### PR DESCRIPTION
# Description

Adds a basic update check using the github releases page. 

# Verification and testing

Asterisk shown in Help menu when current version < released version:

<img width="484" height="302" alt="image" src="https://github.com/user-attachments/assets/a7809417-6c70-4793-8d1e-b19b293b0ade" />

Update available message:

<img width="352" height="239" alt="image" src="https://github.com/user-attachments/assets/df061fc5-f04f-4476-8c99-9c2a3632095e" />

Normal appearance retained when no update available:

<img width="453" height="367" alt="image" src="https://github.com/user-attachments/assets/cf1e99de-ee33-4ed3-b91f-9cbb6b784244" />

**how do you know this won't break in the future?**

Added unit tests for various tag parsing behaviors and github api responses.

# Referenced issues

* Closes #2 
