### PR TITLE
Fix stutter when scrolling with a high-inertia wheel

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,57 +1,44 @@
 # Known Bugs
 
+(none currently)
+
+---
+
+# Resolved Bugs
+
 ## System-wide stutter triggered by scroll wheel + Present() calls
 
+**Status: FIXED** — DirectComposition swap chain with effect group opacity
+
 ### Symptoms
-- After rapid scrolling (zoom or Ctrl+exposure), mouse movement stutters at ~10fps for 5-10 seconds
-- Affects the ENTIRE system: other apps, background video, mouse cursor — not just EXRay
+- After rapid scrolling (zoom or Ctrl+exposure), mouse movement stuttered at ~10fps for 5-10 seconds
+- Affected the ENTIRE system: other apps, background video, mouse cursor — not just EXRay
 - Intermittent: ~25-50% reproducible
-- Resolves on its own after 5-10 seconds
-- Triggered equally by zoom-in and zoom-out
 - Triggered by scroll wheel specifically, not by keyboard/mouse/pan input
 - Hardware: Logitech MagSpeed (high-inertia free-spin) scroll wheel, 175Hz display
 
-### Root cause (confirmed)
-- It is the `Present()` calls during scroll that trigger it — NOT the scroll message volume
-- **Diagnostic proof**: Commenting out `m_needsRedraw = true` in the scroll handler (so scroll updates internal state but never renders) completely eliminates the stutter
-- The issue is in the GPU driver or DWM compositor, not in our code
+### Root cause
+The DWM was promoting the swap chain to **independent flip mode** (handing it directly to the display hardware). Rapid `Present()` calls during scroll caused the DWM to repeatedly transition between composed and independent flip modes. The **mode transition** itself caused the system-wide stutter — not the rendering load.
 
-### What we tried
+**Key evidence**: Running any other windowed app with an active swap chain (even at 60fps) eliminated the stutter, because the DWM was forced to stay in composed mode (can't independent-flip when multiple windows are presenting).
+
+### Fix
+Switched from `CreateSwapChainForHwnd` to `CreateSwapChainForComposition` (DirectComposition) and attached an `IDCompositionEffectGroup` with 254/255 opacity to the visual. The effect group forces the DWM to always composite the visual, preventing independent flip promotion and the problematic mode transitions.
+
+Neither DirectComposition alone nor `IDCompositionVisual3::SetOpacity` alone was sufficient — the DWM optimized those away and still promoted to independent flip. Only an explicit `IDCompositionEffectGroup` with a non-identity effect prevented the promotion. An identity 3D transform (`IDCompositionMatrixTransform3D`) was also optimized away.
+
+The 254/255 opacity introduces a ~0.4% luminance reduction — imperceptible to the eye but measurable with a colorimeter. This is an acceptable tradeoff; no zero-impact alternative exists.
+
+### What we tried (for reference)
 
 | Approach | Result |
 |----------|--------|
 | Throttle to 60fps during scroll | Still stutters |
 | Present(0, 0) (no vsync) during scroll | Still stutters |
 | Present(1, 0) (vsync) during scroll | Still stutters |
-| DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT + SetMaximumFrameLatency(1) | Fixed screen blanking and cursor rendering issues, but scroll stutter persists |
-| Properly waiting on frame latency waitable handle before each render | Still stutters |
+| DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT | Fixed screen blanking and cursor artifacts, stutter persists |
 | Throttle to 30fps during scroll | No stutter, but bad UX |
-| Throttle to 5fps during scroll | No stutter, bad UX |
-| Complete render debounce (0 renders during scroll, 1 render when scroll stops) | No stutter, worst UX |
-| Disabling rendering entirely during scroll (diagnostic) | No stutter — confirms Present() is the trigger |
-
-### Key observations
-- Any sustained `Present()` calls during scroll input triggers the issue, regardless of vsync mode or frame rate (even 60fps triggers it)
-- 30fps was the highest rate tested that avoided the stutter on this hardware, but that's hardware-specific and not a real fix
-- Before adding `DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT`, the issue also caused brief screen blackouts (~30-100ms) and the mouse cursor lost its black outline (rendered as hardware cursor without antialiasing). These symptoms suggest DXGI independent flip / MPO mode transitions. The waitable object flag fixed those visual artifacts but not the underlying stutter.
-- The stutter is NOT present in other apps rendering at the same refresh rate during scroll — so something about our specific DXGI setup is different
-
-### Theories to investigate next
-
-1. **Child window swap chain**: We create the swap chain on a WS_CHILD render area window, not the main window. This is unusual — most apps use the main window or DirectComposition. The DWM/driver may handle child window swap chains differently, possibly falling back to a less optimal composition path that interacts badly with rapid presents during scroll input.
-
-2. **DirectComposition swap chain**: Try `CreateSwapChainForComposition` + `IDCompositionDevice` instead of `CreateSwapChainForHwnd`. This is what modern apps (Chrome, Edge, etc.) use and gives the compositor explicit control over presentation, potentially avoiding the driver issue entirely.
-
-3. **Move swap chain to main window**: Instead of a child window, target the main window and use D3D11 viewport/scissor to render only in the area below the tab bar and above the status bar. Eliminates the child window variable.
-
-4. **DXGI_SCALING_STRETCH vs DXGI_SCALING_NONE**: We use DXGI_SCALING_NONE (for clean resize behavior). Try reverting to SCALING_STRETCH to see if this flag contributes to the issue. Would need an alternative solution for resize stretching.
-
-5. **Test on different GPU/driver**: The issue may be specific to the current GPU driver. Testing on different hardware would confirm whether it's a universal issue or driver-specific.
-
-6. **GPU driver version**: Check if updating/rolling back the GPU driver changes behavior.
-
-### Related changes made during investigation (may want to keep)
-- `DXGI_SCALING_NONE` on swap chain — prevents DWM from stretching old frame during resize
-- `DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT` + `SetMaximumFrameLatency(1)` — prevents independent flip mode transitions (screen blanking, cursor artifacts)
-- Render in `OnResize()` with `Present(0, 0)` — provides live redraw during window resize drag
-- `EndFrame(bool vsync)` parameter — useful for resize renders
+| DirectComposition swap chain (no effect group) | Still stutters |
+| IDCompositionVisual3::SetOpacity(254/255) | Still stutters |
+| IDCompositionEffectGroup + identity 3D transform | Still stutters (DWM optimizes identity away) |
+| **DirectComposition + IDCompositionEffectGroup opacity** | **Fixed** |

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -68,6 +68,7 @@ cc_binary(
         "-DEFAULTLIB:dxgi.lib",
         "-DEFAULTLIB:d3dcompiler.lib",
         "-DEFAULTLIB:dxguid.lib",
+        "-DEFAULTLIB:dcomp.lib",
         "-DEFAULTLIB:comctl32.lib",
         "-DEFAULTLIB:ole32.lib",
         "-DEFAULTLIB:dbghelp.lib",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,7 +39,7 @@ The workflow only runs for tags pushed from `main`.
 - [x] Recent files in File menu
 - [x] Window title shows current filename
 - [x] Embed `VERSIONINFO` resource in RC file (version, copyright, description)
-- [ ] Investigate scroll stutter fix (DirectComposition swap chain or other approach from BUGS.md)
+- [x] Investigate scroll stutter fix (DirectComposition swap chain or other approach from BUGS.md)
 - [x] Update check — background WinHTTP GET to `api.github.com/repos/hughes/EXRay/releases/latest`, compare `tag_name` semver to current version. If newer: asterisk on Help menu, "Update available" line in About dialog. No interruptions. Requires at least one published release to test against.
 - [x] Make sure all environment-specific stuff referencing the local development paths is removed.
 
@@ -110,7 +110,7 @@ The workflow only runs for tags pushed from `main`.
 
 ## 10. Documentation
 
-- [ ] Polish `README.md` — feature list, screenshots/GIF, build instructions, download link
+- [x] Polish `README.md` — feature list, screenshots/GIF, build instructions, download link
 - [x] Keyboard shortcuts / controls reference
 - [x] Supported EXR features and limitations — added to README.md
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -307,16 +307,14 @@ bool Renderer::Initialize(HWND hwnd, bool forceWARP)
     desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
     desc.BufferCount = 2;
     desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+    desc.Scaling = DXGI_SCALING_STRETCH;
 
     if (m_useWARP)
     {
-        // WARP doesn't support DXGI_SCALING_NONE or waitable swap chains
-        desc.Scaling = DXGI_SCALING_STRETCH;
         desc.Flags = 0;
     }
     else
     {
-        desc.Scaling = DXGI_SCALING_NONE;
         desc.Flags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
     }
 
@@ -325,9 +323,57 @@ bool Renderer::Initialize(HWND hwnd, bool forceWARP)
     else
         desc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
 
-    hr = factory->CreateSwapChainForHwnd(m_device.Get(), hwnd, &desc, nullptr, nullptr, &m_swapchain);
-    if (FAILED(hr))
-        return false;
+    // Use DirectComposition swap chain to avoid DWM/driver stutter with
+    // HWND-based child window swap chains during rapid Present() calls.
+    // Falls back to CreateSwapChainForHwnd if DComp setup fails.
+    bool useDComp = !m_useWARP;
+    if (useDComp)
+    {
+        hr = factory->CreateSwapChainForComposition(m_device.Get(), &desc, nullptr, &m_swapchain);
+        if (SUCCEEDED(hr))
+            hr = DCompositionCreateDevice(dxgiDevice.Get(), IID_PPV_ARGS(&m_dcompDevice));
+        if (SUCCEEDED(hr))
+            hr = m_dcompDevice->CreateTargetForHwnd(hwnd, TRUE, &m_dcompTarget);
+        if (SUCCEEDED(hr))
+            hr = m_dcompDevice->CreateVisual(&m_dcompVisual);
+        if (SUCCEEDED(hr))
+        {
+            m_dcompVisual->SetContent(m_swapchain.Get());
+            // Attach an effect group with sub-opaque value to prevent the DWM
+            // from promoting this visual to independent flip mode.  The mode
+            // *transition* (composed ↔ independent flip) during rapid Present()
+            // calls causes system-wide stutter; the effect group forces the DWM
+            // to always composite, avoiding the transition.
+            // 254/255 ≈ 0.996 opacity — imperceptible (<0.4% luminance), but
+            // the DWM cannot optimize it away (identity 3D transforms ARE
+            // optimized away and don't prevent promotion).
+            ComPtr<IDCompositionEffectGroup> effectGroup;
+            if (SUCCEEDED(m_dcompDevice->CreateEffectGroup(&effectGroup)))
+            {
+                effectGroup->SetOpacity(254.0f / 255.0f);
+                m_dcompVisual->SetEffect(effectGroup.Get());
+            }
+            m_dcompTarget->SetRoot(m_dcompVisual.Get());
+            hr = m_dcompDevice->Commit();
+        }
+
+        if (FAILED(hr))
+        {
+            // DComp failed — clean up and fall back to HWND-based
+            m_dcompVisual.Reset();
+            m_dcompTarget.Reset();
+            m_dcompDevice.Reset();
+            m_swapchain.Reset();
+            useDComp = false;
+        }
+    }
+
+    if (!useDComp)
+    {
+        hr = factory->CreateSwapChainForHwnd(m_device.Get(), hwnd, &desc, nullptr, nullptr, &m_swapchain);
+        if (FAILED(hr))
+            return false;
+    }
 
     // Set color space for HDR
     if (m_hdrInfo.isHDRCapable)

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -7,6 +7,7 @@
 #endif
 
 #include <d3d11_1.h>
+#include <dcomp.h>
 #include <dxgi1_6.h>
 #include <windows.h>
 #include <wrl/client.h>
@@ -112,6 +113,12 @@ class Renderer
     ComPtr<ID3D11Texture2D> m_histBgTexture;
     ComPtr<ID3D11ShaderResourceView> m_histBgSRV;
     DXGI_FORMAT m_histBgFormat = DXGI_FORMAT_UNKNOWN;
+
+    // DirectComposition (used instead of HWND-based swap chain to avoid
+    // DWM/driver stutter when presenting during scroll input)
+    ComPtr<IDCompositionDevice> m_dcompDevice;
+    ComPtr<IDCompositionTarget> m_dcompTarget;
+    ComPtr<IDCompositionVisual> m_dcompVisual;
 
     // HDR state
     HDRDisplayInfo m_hdrInfo;


### PR DESCRIPTION
Fixes #1

# Description

Fix system-wide stutter triggered by rapid scroll wheel + Present() calls.

The DWM was promoting our swap chain to independent flip mode, and the repeated transitions between composed and independent flip during rapid scroll input caused system-wide stutter (affecting all apps, cursor, etc. for 5-10 seconds). The fix switches from `CreateSwapChainForHwnd` to a DirectComposition swap chain with an `IDCompositionEffectGroup` at 254/255 opacity, which prevents the DWM from promoting to independent flip while having no perceptible visual impact (<0.4% luminance reduction).

Key finding during investigation: running any other windowed app with an active swap chain eliminated the stutter — because the DWM was already in composed mode and never attempted the problematic transition.

# Verification and testing

Manual testing only: 

- Rapid scroll wheel zoom: 20+ attempts with no reproduction (previously ~25-50% repro rate)
- Window resize: live redraw still works correctly
- HDR output: no regressions
- General rendering (pan, zoom, histogram, pixel grid): no regressions

Also verified that several alternative approaches do NOT work:
- DirectComposition alone (no effect group): DWM still promotes to independent flip
- IDCompositionVisual3::SetOpacity: DWM optimizes it away
- IDCompositionEffectGroup with identity 3D transform: DWM optimizes it away
- Only the effect group with non-identity opacity prevents promotion

# Referenced issues

* #1 
