### PR TITLE
Provide thumnails for EXR files to Windows Explorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ bazel-testlogs/
 *.ilk
 *.lib
 *.exp
+*.dll
 
 # Test artifacts (fetched by tests/fetch_test_images.sh)
 tests/images/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,7 +42,8 @@
             "args": [
                 "build",
                 "-c", "opt",
-                "//:EXRay"
+                "//:EXRay",
+                "//:EXRayThumb.dll"
             ],
             "group": "build",
             "problemMatcher": [
@@ -57,7 +58,7 @@
         {
             "label": "Stage Installer",
             "type": "shell",
-            "command": "cp bazel-out/x64_windows-opt/bin/EXRay.exe installer/ ; attrib -R installer\\EXRay.exe",
+            "command": "Copy-Item -Path bazel-out/x64_windows-opt/bin/EXRay.exe, bazel-out/x64_windows-opt/bin/EXRayThumb.dll -Destination installer/; attrib -R installer\\EXRay.exe; attrib -R installer\\EXRayThumb.dll",
             "group": "build",
             "dependsOn": "Build Installer"
         },

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -77,6 +77,47 @@ cc_binary(
     ],
 )
 
+cc_library(
+    name = "thumbnail_lib",
+    srcs = ["src/thumbnail_provider.cpp"],
+    hdrs = ["src/thumbnail_provider.h"],
+    includes = ["src"],
+    deps = ["@openexr//:OpenEXR"],
+    linkopts = [
+        "-DEFAULTLIB:gdi32.lib",
+        "-DEFAULTLIB:ole32.lib",
+    ],
+)
+
+cc_binary(
+    name = "EXRayThumb.dll",
+    srcs = ["src/thumbnail_dll.cpp"],
+    includes = ["src"],
+    linkshared = True,
+    win_def_file = "src/thumbnail_provider.def",
+    deps = [":thumbnail_lib"],
+    linkopts = [
+        "-DEFAULTLIB:shell32.lib",
+        "-DEFAULTLIB:advapi32.lib",
+        "-DEFAULTLIB:shlwapi.lib",
+    ],
+)
+
+cc_test(
+    name = "thumbnail_test",
+    srcs = ["tests/thumbnail_test.cpp"],
+    includes = ["src"],
+    deps = [
+        ":thumbnail_lib",
+        "@openexr//:OpenEXR",
+    ],
+    linkopts = [
+        "-DEFAULTLIB:gdi32.lib",
+        "-DEFAULTLIB:ole32.lib",
+        "-DEFAULTLIB:shlwapi.lib",
+    ],
+)
+
 cc_test(
     name = "update_checker_test",
     srcs = [

--- a/installer/EXRay.iss
+++ b/installer/EXRay.iss
@@ -1,9 +1,10 @@
 ; EXRay Inno Setup Script
 ; Build the installer with: iscc installer\EXRay.iss
 ;
-; IMPORTANT: Before compiling the installer, build and stage the release binary:
-;   bazelisk build -c opt //:EXRay
+; IMPORTANT: Before compiling the installer, build and stage the release binaries:
+;   bazelisk build -c opt //:EXRay //:EXRayThumb.dll
 ;   cp bazel-out/x64_windows-opt/bin/EXRay.exe installer/
+;   cp bazel-out/x64_windows-opt/bin/EXRayThumb.dll installer/
 ;
 ; The cp step is required because bazel-out is a symlink that iscc can't follow.
 ; Copying from the -opt path guarantees we never package a debug build.
@@ -50,6 +51,7 @@ Name: "fileassoc"; Description: "Associate .exr files with {#MyAppName}"; GroupD
 
 [Files]
 Source: "{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
+Source: "EXRayThumb.dll"; DestDir: "{app}"; Flags: ignoreversion regserver restartreplace uninsrestartdelete
 Source: "..\LICENSE"; DestDir: "{app}"; DestName: "LICENSE.txt"
 Source: "..\THIRD_PARTY_LICENSES"; DestDir: "{app}"; DestName: "THIRD_PARTY_LICENSES.txt"
 

--- a/src/thumbnail_dll.cpp
+++ b/src/thumbnail_dll.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <initguid.h>
+#include "thumbnail_provider.h"
+
+#include <strsafe.h>
+
+long g_dllRefCount = 0;
+static HMODULE g_hModule = nullptr;
+
+static const wchar_t* kCLSID = L"{7B5E2C4A-9F1D-4E8B-A6C3-D2F5E8B1A4C7}";
+static const wchar_t* kFriendlyName = L"EXRay EXR Thumbnail Provider";
+
+// Thumbnail handler shell extension category
+static const wchar_t* kThumbnailHandlerKey =
+    L"Software\\Classes\\.exr\\ShellEx\\{e357fccd-a995-4576-b01f-234630154e96}";
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD reason, LPVOID)
+{
+    if (reason == DLL_PROCESS_ATTACH)
+    {
+        g_hModule = hModule;
+        DisableThreadLibraryCalls(hModule);
+    }
+    return TRUE;
+}
+
+STDAPI DllGetClassObject(REFCLSID clsid, REFIID riid, void** ppv)
+{
+    if (clsid != CLSID_EXRayThumbnailProvider)
+        return CLASS_E_CLASSNOTAVAILABLE;
+
+    static EXRayClassFactory factory;
+    return factory.QueryInterface(riid, ppv);
+}
+
+STDAPI DllCanUnloadNow()
+{
+    return g_dllRefCount == 0 ? S_OK : S_FALSE;
+}
+
+// Registry helpers
+
+static HRESULT SetRegValue(HKEY root, const wchar_t* subKey, const wchar_t* name, const wchar_t* data)
+{
+    HKEY hk;
+    LONG rc = RegCreateKeyExW(root, subKey, 0, nullptr, 0, KEY_SET_VALUE, nullptr, &hk, nullptr);
+    if (rc != ERROR_SUCCESS)
+        return HRESULT_FROM_WIN32(rc);
+    rc = RegSetValueExW(hk, name, 0, REG_SZ, reinterpret_cast<const BYTE*>(data),
+                        static_cast<DWORD>((wcslen(data) + 1) * sizeof(wchar_t)));
+    RegCloseKey(hk);
+    return HRESULT_FROM_WIN32(rc);
+}
+
+static void DeleteRegTree(HKEY root, const wchar_t* subKey)
+{
+    RegDeleteTreeW(root, subKey);
+}
+
+STDAPI DllRegisterServer()
+{
+    wchar_t dllPath[MAX_PATH];
+    GetModuleFileNameW(g_hModule, dllPath, MAX_PATH);
+
+    // HKCU\Software\Classes\CLSID\{...}
+    wchar_t clsidKey[128];
+    StringCchPrintfW(clsidKey, ARRAYSIZE(clsidKey), L"Software\\Classes\\CLSID\\%s", kCLSID);
+
+    HRESULT hr = SetRegValue(HKEY_CURRENT_USER, clsidKey, nullptr, kFriendlyName);
+    if (FAILED(hr))
+        return hr;
+
+    wchar_t inprocKey[256];
+    StringCchPrintfW(inprocKey, ARRAYSIZE(inprocKey), L"%s\\InprocServer32", clsidKey);
+
+    hr = SetRegValue(HKEY_CURRENT_USER, inprocKey, nullptr, dllPath);
+    if (FAILED(hr))
+        return hr;
+
+    hr = SetRegValue(HKEY_CURRENT_USER, inprocKey, L"ThreadingModel", L"Apartment");
+    if (FAILED(hr))
+        return hr;
+
+    // Register as thumbnail handler for .exr
+    hr = SetRegValue(HKEY_CURRENT_USER, kThumbnailHandlerKey, nullptr, kCLSID);
+    if (FAILED(hr))
+        return hr;
+
+    SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+    return S_OK;
+}
+
+STDAPI DllUnregisterServer()
+{
+    wchar_t clsidKey[128];
+    StringCchPrintfW(clsidKey, ARRAYSIZE(clsidKey), L"Software\\Classes\\CLSID\\%s", kCLSID);
+
+    DeleteRegTree(HKEY_CURRENT_USER, clsidKey);
+    DeleteRegTree(HKEY_CURRENT_USER, kThumbnailHandlerKey);
+
+    SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
+    return S_OK;
+}

--- a/src/thumbnail_provider.cpp
+++ b/src/thumbnail_provider.cpp
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "thumbnail_provider.h"
+
+#include <ImfArray.h>
+#include <ImfIO.h>
+#include <ImfRgbaFile.h>
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <vector>
+
+// Adapter: wraps a COM IStream as an OpenEXR Imf::IStream so RgbaInputFile
+// can read directly from the stream Explorer provides.
+class ComStreamAdapter : public Imf::IStream
+{
+  public:
+    ComStreamAdapter(::IStream* pStream)
+        : Imf::IStream("<explorer stream>"), m_pStream(pStream)
+    {
+        m_pStream->AddRef();
+    }
+
+    ~ComStreamAdapter() override
+    {
+        m_pStream->Release();
+    }
+
+    bool read(char c[], int n) override
+    {
+        ULONG totalRead = 0;
+        while (totalRead < static_cast<ULONG>(n))
+        {
+            ULONG bytesRead = 0;
+            HRESULT hr = m_pStream->Read(c + totalRead, n - totalRead, &bytesRead);
+            if (FAILED(hr))
+                throw std::runtime_error("IStream read failed");
+            if (bytesRead == 0)
+                throw std::runtime_error("Unexpected end of stream");
+            totalRead += bytesRead;
+        }
+        return false; // not at EOF after a successful full read
+    }
+
+    uint64_t tellg() override
+    {
+        LARGE_INTEGER zero = {};
+        ULARGE_INTEGER pos;
+        HRESULT hr = m_pStream->Seek(zero, STREAM_SEEK_CUR, &pos);
+        if (FAILED(hr))
+            throw std::runtime_error("IStream seek failed");
+        return pos.QuadPart;
+    }
+
+    void seekg(uint64_t pos) override
+    {
+        LARGE_INTEGER li;
+        li.QuadPart = static_cast<LONGLONG>(pos);
+        HRESULT hr = m_pStream->Seek(li, STREAM_SEEK_SET, nullptr);
+        if (FAILED(hr))
+            throw std::runtime_error("IStream seek failed");
+    }
+
+    void clear() override {}
+
+  private:
+    ::IStream* m_pStream;
+};
+
+EXRayThumbnailProvider::EXRayThumbnailProvider() : m_refCount(1), m_pStream(nullptr)
+{
+    InterlockedIncrement(&g_dllRefCount);
+}
+
+EXRayThumbnailProvider::~EXRayThumbnailProvider()
+{
+    if (m_pStream)
+        m_pStream->Release();
+    InterlockedDecrement(&g_dllRefCount);
+}
+
+IFACEMETHODIMP EXRayThumbnailProvider::QueryInterface(REFIID riid, void** ppv)
+{
+    if (riid == IID_IUnknown || riid == IID_IThumbnailProvider)
+    {
+        *ppv = static_cast<IThumbnailProvider*>(this);
+    }
+    else if (riid == IID_IInitializeWithStream)
+    {
+        *ppv = static_cast<IInitializeWithStream*>(this);
+    }
+    else
+    {
+        *ppv = nullptr;
+        return E_NOINTERFACE;
+    }
+    AddRef();
+    return S_OK;
+}
+
+IFACEMETHODIMP_(ULONG) EXRayThumbnailProvider::AddRef()
+{
+    return InterlockedIncrement(&m_refCount);
+}
+
+IFACEMETHODIMP_(ULONG) EXRayThumbnailProvider::Release()
+{
+    long count = InterlockedDecrement(&m_refCount);
+    if (count == 0)
+        delete this;
+    return count;
+}
+
+IFACEMETHODIMP EXRayThumbnailProvider::Initialize(IStream* pstream, DWORD)
+{
+    if (m_pStream)
+        return HRESULT_FROM_WIN32(ERROR_ALREADY_INITIALIZED);
+    m_pStream = pstream;
+    m_pStream->AddRef();
+    return S_OK;
+}
+
+IFACEMETHODIMP EXRayThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_ALPHATYPE* pdwAlpha)
+{
+    *phbmp = nullptr;
+    *pdwAlpha = WTSAT_ARGB;
+
+    if (!m_pStream)
+        return E_UNEXPECTED;
+
+    try
+    {
+        ComStreamAdapter adapter(m_pStream);
+        Imf::RgbaInputFile file(adapter);
+        Imath::Box2i dw = file.dataWindow();
+
+        int imgW = dw.max.x - dw.min.x + 1;
+        int imgH = dw.max.y - dw.min.y + 1;
+        if (imgW <= 0 || imgH <= 0)
+            return E_FAIL;
+
+        // Compute thumbnail dimensions maintaining aspect ratio
+        UINT thumbW, thumbH;
+        if (imgW >= imgH)
+        {
+            thumbW = cx;
+            thumbH = static_cast<UINT>(static_cast<float>(cx) * imgH / imgW);
+        }
+        else
+        {
+            thumbH = cx;
+            thumbW = static_cast<UINT>(static_cast<float>(cx) * imgW / imgH);
+        }
+        thumbW = (std::max)(thumbW, 1u);
+        thumbH = (std::max)(thumbH, 1u);
+
+        // Create a top-down 32-bit DIB section
+        BITMAPINFO bmi = {};
+        bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+        bmi.bmiHeader.biWidth = static_cast<LONG>(thumbW);
+        bmi.bmiHeader.biHeight = -static_cast<LONG>(thumbH); // top-down
+        bmi.bmiHeader.biPlanes = 1;
+        bmi.bmiHeader.biBitCount = 32;
+        bmi.bmiHeader.biCompression = BI_RGB;
+
+        BYTE* pBits = nullptr;
+        HBITMAP hbmp =
+            CreateDIBSection(nullptr, &bmi, DIB_RGB_COLORS, reinterpret_cast<void**>(&pBits), nullptr, 0);
+        if (!hbmp)
+            return E_OUTOFMEMORY;
+
+        // Read only the scanlines we need. For a 4K image at 256px thumb,
+        // this reads ~16x fewer scanlines than loading the full image.
+        float scaleX = static_cast<float>(imgW) / thumbW;
+        float scaleY = static_cast<float>(imgH) / thumbH;
+
+        // Single-row buffer for reading one scanline at a time
+        std::vector<Imf::Rgba> rowBuf(imgW);
+
+        int lastReadY = -1; // track which scanline is in the buffer
+
+        for (UINT y = 0; y < thumbH; ++y)
+        {
+            int srcY = std::clamp(static_cast<int>((y + 0.5f) * scaleY), 0, imgH - 1);
+            int absY = srcY + dw.min.y;
+
+            // Only read this scanline if we haven't already
+            if (srcY != lastReadY)
+            {
+                file.setFrameBuffer(rowBuf.data() - dw.min.x - static_cast<int64_t>(absY) * imgW, 1, imgW);
+                file.readPixels(absY, absY);
+                lastReadY = srcY;
+            }
+
+            for (UINT x = 0; x < thumbW; ++x)
+            {
+                int srcX = std::clamp(static_cast<int>((x + 0.5f) * scaleX), 0, imgW - 1);
+                const Imf::Rgba& px = rowBuf[srcX];
+
+                float rf = (std::max)(0.0f, static_cast<float>(px.r));
+                float gf = (std::max)(0.0f, static_cast<float>(px.g));
+                float bf = (std::max)(0.0f, static_cast<float>(px.b));
+                float af = std::clamp(static_cast<float>(px.a), 0.0f, 1.0f);
+
+                // Reinhard tone mapping
+                rf = rf / (1.0f + rf);
+                gf = gf / (1.0f + gf);
+                bf = bf / (1.0f + bf);
+
+                // sRGB gamma
+                rf = std::pow(rf, 1.0f / 2.2f);
+                gf = std::pow(gf, 1.0f / 2.2f);
+                bf = std::pow(bf, 1.0f / 2.2f);
+
+                // Premultiply alpha for WTSAT_ARGB
+                rf *= af;
+                gf *= af;
+                bf *= af;
+
+                // Write BGRA
+                BYTE* dst = pBits + (y * thumbW + x) * 4;
+                dst[0] = static_cast<BYTE>(bf * 255.0f + 0.5f);
+                dst[1] = static_cast<BYTE>(gf * 255.0f + 0.5f);
+                dst[2] = static_cast<BYTE>(rf * 255.0f + 0.5f);
+                dst[3] = static_cast<BYTE>(af * 255.0f + 0.5f);
+            }
+        }
+
+        *phbmp = hbmp;
+        return S_OK;
+    }
+    catch (...)
+    {
+        return E_FAIL;
+    }
+}
+
+// ClassFactory
+
+IFACEMETHODIMP EXRayClassFactory::QueryInterface(REFIID riid, void** ppv)
+{
+    if (riid == IID_IUnknown || riid == IID_IClassFactory)
+    {
+        *ppv = static_cast<IClassFactory*>(this);
+        AddRef();
+        return S_OK;
+    }
+    *ppv = nullptr;
+    return E_NOINTERFACE;
+}
+
+IFACEMETHODIMP_(ULONG) EXRayClassFactory::AddRef() { return 2; }
+IFACEMETHODIMP_(ULONG) EXRayClassFactory::Release() { return 1; }
+
+IFACEMETHODIMP EXRayClassFactory::CreateInstance(IUnknown* pUnkOuter, REFIID riid, void** ppv)
+{
+    if (pUnkOuter)
+        return CLASS_E_NOAGGREGATION;
+
+    auto* provider = new (std::nothrow) EXRayThumbnailProvider();
+    if (!provider)
+        return E_OUTOFMEMORY;
+
+    HRESULT hr = provider->QueryInterface(riid, ppv);
+    provider->Release();
+    return hr;
+}
+
+IFACEMETHODIMP EXRayClassFactory::LockServer(BOOL fLock)
+{
+    if (fLock)
+        InterlockedIncrement(&g_dllRefCount);
+    else
+        InterlockedDecrement(&g_dllRefCount);
+    return S_OK;
+}

--- a/src/thumbnail_provider.def
+++ b/src/thumbnail_provider.def
@@ -1,0 +1,6 @@
+LIBRARY EXRayThumb
+EXPORTS
+    DllGetClassObject   PRIVATE
+    DllCanUnloadNow     PRIVATE
+    DllRegisterServer   PRIVATE
+    DllUnregisterServer PRIVATE

--- a/src/thumbnail_provider.h
+++ b/src/thumbnail_provider.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#ifndef UNICODE
+#define UNICODE
+#endif
+
+#include <windows.h>
+#include <propsys.h>
+#include <thumbcache.h>
+#include <shlobj.h>
+
+// {7B5E2C4A-9F1D-4E8B-A6C3-D2F5E8B1A4C7}
+DEFINE_GUID(CLSID_EXRayThumbnailProvider,
+    0x7b5e2c4a, 0x9f1d, 0x4e8b, 0xa6, 0xc3, 0xd2, 0xf5, 0xe8, 0xb1, 0xa4, 0xc7);
+
+extern long g_dllRefCount;
+
+class EXRayThumbnailProvider : public IThumbnailProvider, public IInitializeWithStream
+{
+  public:
+    EXRayThumbnailProvider();
+
+    // IUnknown
+    IFACEMETHODIMP QueryInterface(REFIID riid, void** ppv) override;
+    IFACEMETHODIMP_(ULONG) AddRef() override;
+    IFACEMETHODIMP_(ULONG) Release() override;
+
+    // IInitializeWithStream
+    IFACEMETHODIMP Initialize(IStream* pstream, DWORD grfMode) override;
+
+    // IThumbnailProvider
+    IFACEMETHODIMP GetThumbnail(UINT cx, HBITMAP* phbmp, WTS_ALPHATYPE* pdwAlpha) override;
+
+  private:
+    ~EXRayThumbnailProvider();
+    long m_refCount;
+    IStream* m_pStream;
+};
+
+class EXRayClassFactory : public IClassFactory
+{
+  public:
+    // IUnknown
+    IFACEMETHODIMP QueryInterface(REFIID riid, void** ppv) override;
+    IFACEMETHODIMP_(ULONG) AddRef() override;
+    IFACEMETHODIMP_(ULONG) Release() override;
+
+    // IClassFactory
+    IFACEMETHODIMP CreateInstance(IUnknown* pUnkOuter, REFIID riid, void** ppv) override;
+    IFACEMETHODIMP LockServer(BOOL fLock) override;
+};

--- a/tests/thumbnail_test.cpp
+++ b/tests/thumbnail_test.cpp
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Unit tests for the thumbnail provider.
+// Build & run: bazelisk test //:thumbnail_test
+
+#ifndef UNICODE
+#define UNICODE
+#endif
+
+#include <initguid.h>
+#include "thumbnail_provider.h"
+
+#include <ImfArray.h>
+#include <ImfRgbaFile.h>
+#include <shlwapi.h>
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+// Provide the global that thumbnail_provider.cpp expects.
+long g_dllRefCount = 0;
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define TEST(name)                                                                                 \
+    static void test_##name();                                                                     \
+    struct Register_##name                                                                         \
+    {                                                                                              \
+        Register_##name() { test_##name(); }                                                       \
+    } reg_##name;                                                                                  \
+    static void test_##name()
+
+#define EXPECT(expr)                                                                               \
+    do                                                                                             \
+    {                                                                                              \
+        tests_run++;                                                                               \
+        if (expr)                                                                                  \
+        {                                                                                          \
+            tests_passed++;                                                                        \
+        }                                                                                          \
+        else                                                                                       \
+        {                                                                                          \
+            fprintf(stderr, "  FAIL: %s:%d: %s\n", __FILE__, __LINE__, #expr);                     \
+        }                                                                                          \
+    } while (0)
+
+// Write a small solid-color EXR to a temp file and return its path.
+static std::wstring CreateTestEXR(int width, int height, float r, float g, float b, float a = 1.0f)
+{
+    namespace fs = std::filesystem;
+    fs::path dir = fs::temp_directory_path() / "exray_test";
+    fs::create_directories(dir);
+
+    char name[64];
+    snprintf(name, sizeof(name), "test_%dx%d.exr", width, height);
+    fs::path path = dir / name;
+
+    Imf::Array2D<Imf::Rgba> pixels(height, width);
+    for (int y = 0; y < height; ++y)
+        for (int x = 0; x < width; ++x)
+            pixels[y][x] = Imf::Rgba(half(r), half(g), half(b), half(a));
+
+    Imf::RgbaOutputFile file(path.string().c_str(), width, height, Imf::WRITE_RGBA);
+    file.setFrameBuffer(&pixels[0][0], 1, width);
+    file.writePixels(height);
+
+    return path.wstring();
+}
+
+static void DeleteTestEXR(const std::wstring& path)
+{
+    std::filesystem::remove(path);
+}
+
+// Create an IStream from a file path (what Explorer does for our handler).
+static IStream* StreamFromFile(const std::wstring& path)
+{
+    IStream* pStream = nullptr;
+    SHCreateStreamOnFileEx(path.c_str(), STGM_READ | STGM_SHARE_DENY_WRITE, 0, FALSE, nullptr, &pStream);
+    return pStream;
+}
+
+// Create a provider via COM-style heap allocation, initialized with a file stream.
+static IThumbnailProvider* MakeProvider(const std::wstring& path)
+{
+    auto* p = new EXRayThumbnailProvider();
+    IStream* pStream = StreamFromFile(path);
+    if (pStream)
+    {
+        p->Initialize(pStream, STGM_READ);
+        pStream->Release();
+    }
+    return p; // caller uses Release() to destroy
+}
+
+// Helper to read a pixel from an HBITMAP (top-down 32-bit DIB).
+struct BGRA
+{
+    BYTE b, g, r, a;
+};
+
+static BGRA ReadPixel(HBITMAP hbmp, UINT x, UINT y)
+{
+    BITMAP bm;
+    GetObject(hbmp, sizeof(bm), &bm);
+
+    std::vector<BGRA> bits(bm.bmWidth * std::abs(bm.bmHeight));
+    BITMAPINFO bmi = {};
+    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = bm.bmWidth;
+    bmi.bmiHeader.biHeight = -std::abs(bm.bmHeight); // top-down
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    HDC hdc = CreateCompatibleDC(nullptr);
+    GetDIBits(hdc, hbmp, 0, std::abs(bm.bmHeight), bits.data(), &bmi, DIB_RGB_COLORS);
+    DeleteDC(hdc);
+
+    return bits[y * bm.bmWidth + x];
+}
+
+// --- Tests ---
+
+TEST(GetThumbnail_basic)
+{
+    std::wstring path = CreateTestEXR(100, 100, 1.0f, 0.0f, 0.0f);
+    IThumbnailProvider* prov = MakeProvider(path);
+
+    HBITMAP hbmp = nullptr;
+    WTS_ALPHATYPE alpha = WTSAT_UNKNOWN;
+    HRESULT hr = prov->GetThumbnail(64, &hbmp, &alpha);
+
+    EXPECT(hr == S_OK);
+    EXPECT(hbmp != nullptr);
+    EXPECT(alpha == WTSAT_ARGB);
+
+    if (hbmp)
+    {
+        BITMAP bm;
+        GetObject(hbmp, sizeof(bm), &bm);
+        EXPECT(bm.bmWidth == 64);
+        EXPECT(bm.bmHeight == 64);
+        DeleteObject(hbmp);
+    }
+
+    prov->Release();
+    DeleteTestEXR(path);
+}
+
+TEST(GetThumbnail_landscape_aspect_ratio)
+{
+    std::wstring path = CreateTestEXR(200, 100, 0.0f, 1.0f, 0.0f);
+    IThumbnailProvider* prov = MakeProvider(path);
+
+    HBITMAP hbmp = nullptr;
+    WTS_ALPHATYPE alpha;
+    HRESULT hr = prov->GetThumbnail(128, &hbmp, &alpha);
+
+    EXPECT(hr == S_OK);
+    if (hbmp)
+    {
+        BITMAP bm;
+        GetObject(hbmp, sizeof(bm), &bm);
+        EXPECT(bm.bmWidth == 128); // full width
+        EXPECT(bm.bmHeight == 64); // half height (2:1 aspect)
+        DeleteObject(hbmp);
+    }
+
+    prov->Release();
+    DeleteTestEXR(path);
+}
+
+TEST(GetThumbnail_portrait_aspect_ratio)
+{
+    std::wstring path = CreateTestEXR(100, 200, 0.0f, 0.0f, 1.0f);
+    IThumbnailProvider* prov = MakeProvider(path);
+
+    HBITMAP hbmp = nullptr;
+    WTS_ALPHATYPE alpha;
+    HRESULT hr = prov->GetThumbnail(128, &hbmp, &alpha);
+
+    EXPECT(hr == S_OK);
+    if (hbmp)
+    {
+        BITMAP bm;
+        GetObject(hbmp, sizeof(bm), &bm);
+        EXPECT(bm.bmWidth == 64);  // half width (1:2 aspect)
+        EXPECT(bm.bmHeight == 128); // full height
+        DeleteObject(hbmp);
+    }
+
+    prov->Release();
+    DeleteTestEXR(path);
+}
+
+TEST(GetThumbnail_tone_mapping)
+{
+    // A pixel with value 1.0 should tone-map to 0.5, then gamma to ~0.73
+    std::wstring path = CreateTestEXR(4, 4, 1.0f, 1.0f, 1.0f);
+    IThumbnailProvider* prov = MakeProvider(path);
+
+    HBITMAP hbmp = nullptr;
+    WTS_ALPHATYPE alpha;
+    prov->GetThumbnail(4, &hbmp, &alpha);
+
+    if (hbmp)
+    {
+        BGRA px = ReadPixel(hbmp, 0, 0);
+        // Reinhard(1.0) = 0.5, gamma(0.5) = 0.5^(1/2.2) ~ 0.73, * 255 ~ 186
+        EXPECT(px.r > 170 && px.r < 200);
+        EXPECT(px.g > 170 && px.g < 200);
+        EXPECT(px.b > 170 && px.b < 200);
+        EXPECT(px.a == 255);
+        DeleteObject(hbmp);
+    }
+
+    prov->Release();
+    DeleteTestEXR(path);
+}
+
+TEST(GetThumbnail_bright_values_compressed)
+{
+    // Very bright values (100.0) should be compressed close to 1.0 by Reinhard
+    std::wstring path = CreateTestEXR(4, 4, 100.0f, 100.0f, 100.0f);
+    IThumbnailProvider* prov = MakeProvider(path);
+
+    HBITMAP hbmp = nullptr;
+    WTS_ALPHATYPE alpha;
+    prov->GetThumbnail(4, &hbmp, &alpha);
+
+    if (hbmp)
+    {
+        BGRA px = ReadPixel(hbmp, 0, 0);
+        // Reinhard(100) = 100/101 ~ 0.99, gamma ~ 0.995, * 255 ~ 254
+        EXPECT(px.r >= 250);
+        EXPECT(px.g >= 250);
+        EXPECT(px.b >= 250);
+        DeleteObject(hbmp);
+    }
+
+    prov->Release();
+    DeleteTestEXR(path);
+}
+
+TEST(GetThumbnail_dark_values)
+{
+    std::wstring path = CreateTestEXR(4, 4, 0.01f, 0.01f, 0.01f);
+    IThumbnailProvider* prov = MakeProvider(path);
+
+    HBITMAP hbmp = nullptr;
+    WTS_ALPHATYPE alpha;
+    prov->GetThumbnail(4, &hbmp, &alpha);
+
+    if (hbmp)
+    {
+        BGRA px = ReadPixel(hbmp, 0, 0);
+        // Reinhard(0.01) ~ 0.0099, gamma ~ 0.125, * 255 ~ 32
+        EXPECT(px.r > 20 && px.r < 50);
+        DeleteObject(hbmp);
+    }
+
+    prov->Release();
+    DeleteTestEXR(path);
+}
+
+TEST(GetThumbnail_no_stream)
+{
+    auto* prov = new EXRayThumbnailProvider();
+    // Don't call Initialize — no stream set
+
+    HBITMAP hbmp = nullptr;
+    WTS_ALPHATYPE alpha;
+    HRESULT hr = prov->GetThumbnail(64, &hbmp, &alpha);
+
+    EXPECT(FAILED(hr));
+    EXPECT(hbmp == nullptr);
+
+    prov->Release();
+}
+
+TEST(QueryInterface_supported)
+{
+    auto* prov = new EXRayThumbnailProvider();
+
+    IThumbnailProvider* pThumb = nullptr;
+    EXPECT(prov->QueryInterface(IID_IThumbnailProvider, (void**)&pThumb) == S_OK);
+    if (pThumb)
+        pThumb->Release();
+
+    IInitializeWithStream* pInit = nullptr;
+    EXPECT(prov->QueryInterface(IID_IInitializeWithStream, (void**)&pInit) == S_OK);
+    if (pInit)
+        pInit->Release();
+
+    IUnknown* pUnk = nullptr;
+    EXPECT(prov->QueryInterface(IID_IUnknown, (void**)&pUnk) == S_OK);
+    if (pUnk)
+        pUnk->Release();
+
+    prov->Release();
+}
+
+TEST(QueryInterface_unsupported)
+{
+    auto* prov = new EXRayThumbnailProvider();
+
+    IClassFactory* pFactory = nullptr;
+    EXPECT(prov->QueryInterface(IID_IClassFactory, (void**)&pFactory) == E_NOINTERFACE);
+    EXPECT(pFactory == nullptr);
+
+    prov->Release();
+}
+
+TEST(RefCounting)
+{
+    auto* prov = new EXRayThumbnailProvider();
+    // Starts at 1
+    EXPECT(prov->AddRef() == 2);
+    EXPECT(prov->AddRef() == 3);
+    EXPECT(prov->Release() == 2);
+    EXPECT(prov->Release() == 1);
+    prov->Release(); // ref hits 0, deletes
+}
+
+TEST(ClassFactory_creates_provider)
+{
+    EXRayClassFactory factory;
+
+    IThumbnailProvider* pThumb = nullptr;
+    HRESULT hr = factory.CreateInstance(nullptr, IID_IThumbnailProvider, (void**)&pThumb);
+    EXPECT(hr == S_OK);
+    EXPECT(pThumb != nullptr);
+    if (pThumb)
+        pThumb->Release();
+}
+
+TEST(ClassFactory_rejects_aggregation)
+{
+    EXRayClassFactory factory;
+    IUnknown* dummy = reinterpret_cast<IUnknown*>(1);
+    IThumbnailProvider* pThumb = nullptr;
+    HRESULT hr = factory.CreateInstance(dummy, IID_IThumbnailProvider, (void**)&pThumb);
+    EXPECT(hr == CLASS_E_NOAGGREGATION);
+}
+
+int main()
+{
+    printf("thumbnail_test: %d/%d passed\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}


### PR DESCRIPTION
# Description

Add a Windows Explorer thumbnail provider shell extension (EXRayThumb.dll) so .exr files show image previews in Explorer. The DLL implements IThumbnailProvider and IInitializeWithStream via COM — Explorer opens the file and passes a stream to the handler, which reads it through an adapter bridging COM's IStream to OpenEXR's Imf::IStream. Reinhard tone mapping with sRGB gamma converts HDR to viewable thumbnails. Only the scanlines needed for the target thumbnail size are read, keeping extraction fast even for large images. Registration uses HKCU so no admin elevation is needed. The installer bundles and registers the DLL automatically.

# Verification and testing

Built the DLL, registered it with regsvr32, and confirmed Explorer shows EXR thumbnails across multiple folders including a 300-frame image sequence. Tested install/uninstall cycle via the Inno Setup installer — thumbnails appear immediately after install and are cleaned up on uninstall.

33 automated tests (bazelisk test //:thumbnail_test) cover thumbnail generation (valid output, aspect ratio preservation for landscape/portrait, tone mapping accuracy across dark/mid/bright HDR values), error handling (missing stream), and COM plumbing (QueryInterface, ref counting, ClassFactory, aggregation rejection). Tests create EXR files programmatically so they're self-contained with no test data dependencies.

<img width="759" height="378" alt="image" src="https://github.com/user-attachments/assets/b91877b9-0b3f-44a5-9b02-4dd2ab5ff138" />

<img width="506" height="249" alt="image" src="https://github.com/user-attachments/assets/be15f879-f235-4265-beb2-f67b14f69d96" />
