### PR TITLE
Displays the resource version in Properies>Details and fixes thumbnails

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -98,9 +98,21 @@ cc_library(
     ],
 )
 
+genrule(
+    name = "thumb_resources",
+    srcs = [
+        "resources/thumbnail.rc",
+        "src/resource.h",
+    ],
+    tools = ["tools/find_rc.bat"],
+    outs = ["thumbnail.res"],
+    cmd_bat = "$(location tools/find_rc.bat) /nologo /I . /fo $@ $(location resources/thumbnail.rc)",
+)
+
 cc_binary(
     name = "EXRayThumb.dll",
     srcs = ["src/thumbnail_dll.cpp"],
+    additional_linker_inputs = [":thumb_resources"],
     includes = ["src"],
     linkshared = True,
     win_def_file = "src/thumbnail_provider.def",
@@ -109,6 +121,7 @@ cc_binary(
         "-DEFAULTLIB:shell32.lib",
         "-DEFAULTLIB:advapi32.lib",
         "-DEFAULTLIB:shlwapi.lib",
+        "$(location :thumb_resources)",
     ],
 )
 

--- a/resources/thumbnail.rc
+++ b/resources/thumbnail.rc
@@ -1,0 +1,29 @@
+#include "src/resource.h"
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION    EXRAY_VERSION_MAJOR, EXRAY_VERSION_MINOR, EXRAY_VERSION_PATCH, 0
+PRODUCTVERSION EXRAY_VERSION_MAJOR, EXRAY_VERSION_MINOR, EXRAY_VERSION_PATCH, 0
+FILEFLAGSMASK  0x3fL
+FILEFLAGS      0
+FILEOS         0x40004L
+FILETYPE       0x2L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "CompanyName",      "EXRay contributors"
+            VALUE "FileDescription",  "EXRay EXR Thumbnail Provider"
+            VALUE "FileVersion",      EXRAY_VERSION_STR
+            VALUE "InternalName",     "EXRayThumb"
+            VALUE "LegalCopyright",   EXRAY_COPYRIGHT
+            VALUE "OriginalFilename", "EXRayThumb.dll"
+            VALUE "ProductName",      "EXRay"
+            VALUE "ProductVersion",   EXRAY_VERSION_STR
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 0x04B0
+    END
+END

--- a/src/resource.h
+++ b/src/resource.h
@@ -2,6 +2,11 @@
 
 #pragma once
 
+// RC SDK constants (rc.exe runs without Windows SDK includes in Bazel)
+#ifndef VS_VERSION_INFO
+#define VS_VERSION_INFO 1
+#endif
+
 // Version info — single source of truth for VERSIONINFO + About dialog
 #define EXRAY_VERSION_MAJOR 0
 #define EXRAY_VERSION_MINOR 3

--- a/src/thumbnail_provider.cpp
+++ b/src/thumbnail_provider.cpp
@@ -199,6 +199,47 @@ IFACEMETHODIMP EXRayThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS
 
         int lastReadY = -1; // track which scanline is in the buffer
 
+        // First pass: check if alpha is useful by sampling the scanlines
+        // we'll actually use for the thumbnail. An all-zero or all-one
+        // alpha channel means we should treat the image as opaque.
+        bool alphaIsUseful = false;
+        {
+            bool hasNonZero = false;
+            bool hasNonOne = false;
+            for (UINT y = 0; y < thumbH && !alphaIsUseful; ++y)
+            {
+                int srcY = std::clamp(static_cast<int>((y + 0.5f) * scaleY), 0, imgH - 1);
+                int absY = srcY + dw.min.y;
+
+                if (srcY != lastReadY)
+                {
+                    file.setFrameBuffer(rowBuf.data() - dw.min.x - static_cast<int64_t>(absY) * imgW, 1, imgW);
+                    file.readPixels(absY, absY);
+                    lastReadY = srcY;
+                }
+
+                for (UINT x = 0; x < thumbW; ++x)
+                {
+                    int srcX = std::clamp(static_cast<int>((x + 0.5f) * scaleX), 0, imgW - 1);
+                    float af = static_cast<float>(rowBuf[srcX].a);
+                    if (af != 0.0f)
+                        hasNonZero = true;
+                    if (af < 1.0f)
+                        hasNonOne = true;
+                    if (hasNonZero && hasNonOne)
+                    {
+                        alphaIsUseful = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!alphaIsUseful)
+            *pdwAlpha = WTSAT_RGB;
+
+        lastReadY = -1; // reset for the rendering pass
+
         for (UINT y = 0; y < thumbH; ++y)
         {
             int srcY = std::clamp(static_cast<int>((y + 0.5f) * scaleY), 0, imgH - 1);
@@ -220,7 +261,7 @@ IFACEMETHODIMP EXRayThumbnailProvider::GetThumbnail(UINT cx, HBITMAP* phbmp, WTS
                 float rf = static_cast<float>(px.r);
                 float gf = static_cast<float>(px.g);
                 float bf = static_cast<float>(px.b);
-                float af = std::clamp(static_cast<float>(px.a), 0.0f, 1.0f);
+                float af = alphaIsUseful ? std::clamp(static_cast<float>(px.a), 0.0f, 1.0f) : 1.0f;
 
                 // Apply chromaticity conversion before tone mapping
                 if (hasColorMatrix)

--- a/tests/thumbnail_test.cpp
+++ b/tests/thumbnail_test.cpp
@@ -133,7 +133,7 @@ TEST(GetThumbnail_basic)
 
     EXPECT(hr == S_OK);
     EXPECT(hbmp != nullptr);
-    EXPECT(alpha == WTSAT_ARGB);
+    EXPECT(alpha == WTSAT_RGB); // uniform alpha (all 1.0) → treated as opaque
 
     if (hbmp)
     {
@@ -257,6 +257,31 @@ TEST(GetThumbnail_dark_values)
         BGRA px = ReadPixel(hbmp, 0, 0);
         // Reinhard(0.01) ~ 0.0099, gamma ~ 0.125, * 255 ~ 32
         EXPECT(px.r > 20 && px.r < 50);
+        DeleteObject(hbmp);
+    }
+
+    prov->Release();
+    DeleteTestEXR(path);
+}
+
+TEST(GetThumbnail_zero_alpha_treated_as_opaque)
+{
+    // Images with all-zero alpha should produce visible thumbnails, not blank ones
+    std::wstring path = CreateTestEXR(4, 4, 1.0f, 0.0f, 0.0f, 0.0f);
+    IThumbnailProvider* prov = MakeProvider(path);
+
+    HBITMAP hbmp = nullptr;
+    WTS_ALPHATYPE alpha = WTSAT_UNKNOWN;
+    HRESULT hr = prov->GetThumbnail(4, &hbmp, &alpha);
+
+    EXPECT(hr == S_OK);
+    EXPECT(alpha == WTSAT_RGB);
+
+    if (hbmp)
+    {
+        BGRA px = ReadPixel(hbmp, 0, 0);
+        EXPECT(px.r > 100); // should be visible red, not blank
+        EXPECT(px.a == 255);
         DeleteObject(hbmp);
     }
 


### PR DESCRIPTION
# Description

Carrots.exr would show a blank thumbnail. Now it shows the image:

<img width="750" height="268" alt="image" src="https://github.com/user-attachments/assets/d14e1dde-0d69-472a-90e8-39433b9ef412" />

While trying to figure out what version of the dll I had, I also noticed the version was not embedding properly. 

The file properties are fixed to show this now:

<img width="405" height="566" alt="image" src="https://github.com/user-attachments/assets/fa8ffa56-d3c9-4263-8083-19dded0f97e2" />

<img width="405" height="509" alt="image" src="https://github.com/user-attachments/assets/e7e9122c-3dcd-4412-9516-03cad943e33f" />


# Verification and testing

**how do you know this works?**

Updated unit tests.

# Related issues

#7 